### PR TITLE
Fix #2: Adjacency list modifications occur when connection between tw…

### DIFF
--- a/src/components/layout/toolbar.fixture.tsx
+++ b/src/components/layout/toolbar.fixture.tsx
@@ -11,7 +11,7 @@ import { useState, useEffect } from 'react';
 
 import '../../index.css';
 
-import { useGraphStore, useCollisionManager } from '../utils/graph.store';
+import { useGraphStore, useCollisionManager, useAdjacencyList } from '../utils/graph.store';
 import { NodeID } from '../utils/node';
 import { EdgeID } from '../utils/edge';
 import { ComponentType, isEdge } from '../utils/graph.interfaces';
@@ -25,6 +25,7 @@ let edge: EdgeID = 0;
 
 const Toolbar = () => {
     const graphComponents = useGraphStore(state => state.graphComponents);
+    let adjacencyList = useAdjacencyList(state => state);
     let collisionManager = useCollisionManager(state => state);
 
     const [ center, setCenterXYSVG ] = useState([0, 0]);
@@ -59,9 +60,11 @@ const Toolbar = () => {
         const gridCells = collisionManager.getCellsInCircle(cx, cy);
         collisionManager.addToNodeGrid(gridCells, id);
         useCollisionManager.setState(collisionManager);
+        adjacencyList = useAdjacencyList.getState()
+        adjacencyList.set(id, new Set<NodeID>());
+        useAdjacencyList.setState(adjacencyList);
         useGraphStore.setState(
             {
-                adjacencyList: useGraphStore.getState().adjacencyList,
                 graphComponents: {
                     nodes: new Map(
                         [
@@ -102,7 +105,6 @@ const Toolbar = () => {
         useCollisionManager.setState(collisionManager);
         useGraphStore.setState(
             {
-                adjacencyList: useGraphStore.getState().adjacencyList,
                 graphComponents: {
                     nodes: graphComponents.nodes,
                     edges: new Map(
@@ -110,8 +112,8 @@ const Toolbar = () => {
                             ...graphComponents.edges, 
                             [ id, 
                                 {
-                                    to: -1, 
-                                    from: -1, 
+                                    to: undefined, 
+                                    from: undefined, 
                                     cost: 0,
                                     type:componentType,
                                     x1: x1,

--- a/src/components/utils/graph.interfaces.tsx
+++ b/src/components/utils/graph.interfaces.tsx
@@ -14,7 +14,7 @@ export interface GraphComponents {
     edges: Map<EdgeID, EdgeIF>
 }
 
-export type AdjacencyList = Map<NodeID, Set<EdgeID>>;
+export type AdjacencyList = Map<NodeID, Set<NodeID>>;
 
 export interface ConnectedComponents {
     [nodes: NodeID]: [NodeID | undefined]

--- a/src/components/utils/graph.store.tsx
+++ b/src/components/utils/graph.store.tsx
@@ -8,8 +8,7 @@
 
 import { 
     GraphComponents, 
-    AdjacencyList, 
-    ConnectedComponents 
+    AdjacencyList
 } from './graph.interfaces';
 
 import { create } from 'zustand';
@@ -22,18 +21,18 @@ import { CollisionManager } from './collision-manager';
  */
 interface GraphStore {
     graphComponents: GraphComponents,
-    adjacencyList: AdjacencyList,
-    connectedComponents?: ConnectedComponents, // TODO (If useful) 
 };
 
 export const useGraphStore = create<GraphStore>(() => ({
     graphComponents: {
         nodes: new Map<NodeID, NodeIF>(),
         edges: new Map<EdgeID, EdgeIF>()
-    },
-    adjacencyList: new Map<NodeID, Set<EdgeID>>(),
-    // connectedComponents: {} TODO (If useful)
+    }
 }));
+
+export const useAdjacencyList = create<AdjacencyList>(() => (
+    new Map<NodeID, Set<NodeID>>()
+));
 
 export const useCollisionManager = create<CollisionManager>(() => (
     new CollisionManager()


### PR DESCRIPTION
1. When nodes move, appropriate changes to the adjacency list are made to reflect the UI state.
2. When edges move, appropriate changes to the adjacency list are made to reflect the UI state. 
3. Adjacency list modifications take directionality of the edge into account. 