### PR TITLE
Vertex rotation and scaling PR

### DIFF
--- a/src/components/graph/edge-highlighter.tsx
+++ b/src/components/graph/edge-highlighter.tsx
@@ -1,0 +1,55 @@
+import { triangleStyleInfo } from '../utils/edge';
+import { styleInfo as nodeStyleInfo } from  '../utils/node';
+import { HighlighterKnob } from '../graph/highlighter';
+import { ComponentType } from '../utils/graph.interfaces';
+
+
+
+export const EdgeHighlighter = (
+    {x1, x2, y1, y2, type}:
+    {x1: number, x2: number, y1: number, y2: number, type: ComponentType}) => {
+    return (
+        <g>
+            <line
+                x1={x1}
+                x2={x2}
+                y1={y1}
+                y2={y2}
+                strokeWidth={nodeStyleInfo.strokeWidth}
+                stroke="red"
+                strokeDasharray="2,6"
+                strokeLinecap="round"
+                strokeOpacity={0.4}
+            />
+            <g  
+                className="hover:cursor-grab"
+            >
+                <HighlighterKnob
+                    cx={x1}
+                    cy={y1}
+                />
+            </g>
+
+                <g  
+                className="hover:cursor-grab"
+            >
+                <HighlighterKnob
+                    cx={x2}
+                    cy={y2}
+                />
+            </g>
+
+            {
+                type === ComponentType.UNIDIRECTIONALEDGE &&
+                <polygon 
+                    points = {`${x2-triangleStyleInfo.sideLength},${y2} ${x2},${y2} ${x2},${y2+triangleStyleInfo.sideLength}`} 
+                    stroke="red"
+                    strokeDasharray="2,6"
+                    strokeLinecap="round"
+                    strokeOpacity={0.4}
+                />
+            }
+            
+        </g>
+    )
+}

--- a/src/components/graph/edge-highlighter.tsx
+++ b/src/components/graph/edge-highlighter.tsx
@@ -3,53 +3,61 @@ import { styleInfo as nodeStyleInfo } from  '../utils/node';
 import { HighlighterKnob } from '../graph/highlighter';
 import { ComponentType } from '../utils/graph.interfaces';
 
-
-
 export const EdgeHighlighter = (
-    {x1, x2, y1, y2, type}:
-    {x1: number, x2: number, y1: number, y2: number, type: ComponentType}) => {
-    return (
-        <g>
-            <line
-                x1={x1}
-                x2={x2}
-                y1={y1}
-                y2={y2}
-                strokeWidth={nodeStyleInfo.strokeWidth}
-                stroke="red"
-                strokeDasharray="2,6"
-                strokeLinecap="round"
-                strokeOpacity={0.4}
-            />
-            <g  
-                className="hover:cursor-grab"
-            >
-                <HighlighterKnob
-                    cx={x1}
-                    cy={y1}
-                />
-            </g>
-
-                <g  
-                className="hover:cursor-grab"
-            >
-                <HighlighterKnob
-                    cx={x2}
-                    cy={y2}
-                />
-            </g>
-
-            {
-                type === ComponentType.UNIDIRECTIONALEDGE &&
-                <polygon 
-                    points = {`${x2-triangleStyleInfo.sideLength},${y2} ${x2},${y2} ${x2},${y2+triangleStyleInfo.sideLength}`} 
+    {x1, x2, y1, y2, type, onMouseDownX1Y1, onMouseDownX2Y2}:
+    {x1: number, x2: number, y1: number, y2: number, type: ComponentType, onMouseDownX1Y1?: React.MouseEventHandler<SVGGElement>, onMouseDownX2Y2?: React.MouseEventHandler<SVGGElement>}) => {
+    
+        return (
+            <g>
+                <line
+                    x1={x1}
+                    x2={x2}
+                    y1={y1}
+                    y2={y2}
+                    strokeWidth={nodeStyleInfo.strokeWidth}
                     stroke="red"
                     strokeDasharray="2,6"
                     strokeLinecap="round"
                     strokeOpacity={0.4}
                 />
-            }
-            
-        </g>
-    )
+
+                {/* We only want this to render if this highlight is not used to represent repositioning */}
+                {   onMouseDownX1Y1 !== undefined &&
+                    <g  
+                    className="hover:cursor-grab"
+                    onMouseDown={e => onMouseDownX1Y1(e)}
+                    >
+                        <HighlighterKnob
+                            cx={x1}
+                            cy={y1}
+                        />
+                    </g>
+                }
+
+                {/* We only want this to render if this highlight is not used to represent repositioning */}
+                {   onMouseDownX2Y2 !== undefined && 
+                    <g  
+                    className="hover:cursor-grab"
+                    onMouseDown={e => onMouseDownX2Y2(e)}
+                    >
+                            <HighlighterKnob
+                                cx={x2}
+                                cy={y2}
+                            />
+                    </g>
+                }
+
+                {
+                    type === ComponentType.UNIDIRECTIONALEDGE &&
+                    <polygon 
+                        points = {`${x2-triangleStyleInfo.sideLength},${y2} ${x2},${y2} ${x2},${y2+triangleStyleInfo.sideLength}`} 
+                        stroke="red"
+                        strokeDasharray="2,6"
+                        strokeLinecap="round"
+                        strokeOpacity={0.4}
+                    />
+                }
+                
+            </g>
+        )
 }

--- a/src/components/graph/edge-highlighter.tsx
+++ b/src/components/graph/edge-highlighter.tsx
@@ -50,11 +50,11 @@ export const EdgeHighlighter = (
                 {
                     type === ComponentType.UNIDIRECTIONALEDGE &&
                     <polygon 
-                        points = {`${x2-triangleStyleInfo.sideLength},${y2} ${x2},${y2} ${x2},${y2+triangleStyleInfo.sideLength}`} 
-                        stroke="red"
+                        points = {`${x2},${y2} ${x2-triangleStyleInfo.sideLength},${y2+triangleStyleInfo.sideLength} ${x2+triangleStyleInfo.sideLength},${y2+triangleStyleInfo.sideLength}`}                         stroke="red"
                         strokeDasharray="2,6"
                         strokeLinecap="round"
                         strokeOpacity={0.4}
+                        transform={`rotate(${((Math.atan2(y2 - y1, x2 - x1) + Math.PI/2) * 180) / Math.PI}, ${x2}, ${y2})`}
                     />
                 }
                 

--- a/src/components/graph/edge.fixture.tsx
+++ b/src/components/graph/edge.fixture.tsx
@@ -58,8 +58,9 @@ import { styleInfo as nodeStyleInfo } from  '../utils/node';
             {
                 type === ComponentType.UNIDIRECTIONALEDGE &&
                 <polygon 
-                    points = {`${x2-triangleStyleInfo.sideLength},${y2} ${x2},${y2} ${x2},${y2+triangleStyleInfo.sideLength}`} 
+                    points = {`${x2},${y2} ${x2-triangleStyleInfo.sideLength},${y2+triangleStyleInfo.sideLength} ${x2+triangleStyleInfo.sideLength},${y2+triangleStyleInfo.sideLength}`} 
                     fill="black" 
+                    transform={`rotate(${((Math.atan2(y2 - y1, x2 - x1) + Math.PI/2) * 180) / Math.PI}, ${x2}, ${y2})`}
                 />
             }
             

--- a/src/components/graph/highlighter.tsx
+++ b/src/components/graph/highlighter.tsx
@@ -28,7 +28,9 @@ export const Highlighter = (
         x2,
         y1,
         y2,
-        onMouseDown = undefined
+        onMouseDown = undefined,
+        onMouseDownX1Y1 = undefined,
+        onMouseDownX2Y2 = undefined
     }:
     {
         isActive: boolean,
@@ -39,7 +41,9 @@ export const Highlighter = (
         x2?: number,
         y1?: number,
         y2?: number,
-        onMouseDown?: React.MouseEventHandler<SVGGElement> | undefined
+        onMouseDown?: React.MouseEventHandler<SVGGElement> | undefined,
+        onMouseDownX1Y1?: React.MouseEventHandler<SVGGElement> | undefined, 
+        onMouseDownX2Y2?: React.MouseEventHandler<SVGGElement> | undefined
     }
 ) => {
 
@@ -65,6 +69,8 @@ export const Highlighter = (
                     y1 = { y1 }
                     y2 = { y2 }
                     type = { type }
+                    onMouseDownX1Y1 = { onMouseDownX1Y1 }
+                    onMouseDownX2Y2 = { onMouseDownX2Y2 }
                 />
             }
 

--- a/src/components/graph/highlighter.tsx
+++ b/src/components/graph/highlighter.tsx
@@ -1,18 +1,21 @@
 import '../../index.css';
 import { ComponentType, isEdge } from '../utils/graph.interfaces';
-import { triangleStyleInfo } from '../utils/edge';
-import { styleInfo as nodeStyleInfo, highlighterStyleInfo } from  '../utils/node';
+import { highlighterStyleInfo } from  '../utils/node';
+import { NodeHighlighter } from './node-highlighter';
+import { EdgeHighlighter } from './edge-highlighter';
 
-const HighlighterKnob = ({ cx, cy }: { cx: number, cy: number }) => {
-    return (<circle
-        cx={ cx }
-        cy={ cy }
-        r={ highlighterStyleInfo.radius }
-        stroke="red"
-        fill="red"
-        fillOpacity={0.4}
-        strokeWidth={highlighterStyleInfo.strokeWidth}
-    />)
+export const HighlighterKnob = ({ cx, cy }: { cx: number, cy: number }) => {
+    return (
+        <circle
+            cx={ cx }
+            cy={ cy }
+            r={ highlighterStyleInfo.radius }
+            stroke="red"
+            fill="red"
+            fillOpacity={0.4}
+            strokeWidth={highlighterStyleInfo.strokeWidth}
+        />
+    )
 }
 
 export const Highlighter = (
@@ -39,6 +42,9 @@ export const Highlighter = (
         onMouseDown?: React.MouseEventHandler<SVGGElement> | undefined
     }
 ) => {
+
+
+
     return (
         <g
             className = { isActive && onMouseDown !== undefined ? `hover:cursor-move` : '' }
@@ -48,110 +54,29 @@ export const Highlighter = (
                 onMouseDown(e);
             }}
         >
-            {/* Node highlight */}
-            { 
-                isActive && type === ComponentType.NODE 
-                && cx !== undefined && cy !== undefined &&
-                <rect
-                    height= { nodeStyleInfo.radius * 2 }
-                    width = { nodeStyleInfo.radius * 2 }
-                    x = { cx - nodeStyleInfo.radius }
-                    y = { cy - nodeStyleInfo.radius }
-                    strokeWidth={nodeStyleInfo.strokeWidth}
-                    stroke="red"
-                    strokeDasharray="2,6"
-                    strokeLinecap="round"
-                    fill="transparent"
-                    strokeOpacity={0.4}
-                />
-
-                
-            }
-
-
-            {
-                isActive && type === ComponentType.NODE 
-                && cx !== undefined && cy !== undefined &&
-                <HighlighterKnob
-                    cx={ cx - nodeStyleInfo.radius }
-                    cy={ cy - nodeStyleInfo.radius }
-                />
-            }
-
-            {
-                isActive && type === ComponentType.NODE 
-                && cx !== undefined && cy !== undefined &&
-                <HighlighterKnob
-                    cx={ cx + nodeStyleInfo.radius }
-                    cy={ cy - nodeStyleInfo.radius }
-                />
-            }
-
-            {
-                isActive && type === ComponentType.NODE 
-                && cx !== undefined && cy !== undefined &&
-                <HighlighterKnob
-                    cx={ cx - nodeStyleInfo.radius }
-                    cy={ cy + nodeStyleInfo.radius }
-                />
-            }
-
-            {
-                isActive && type === ComponentType.NODE 
-                && cx !== undefined && cy !== undefined &&
-                <HighlighterKnob
-                    cx={ cx + nodeStyleInfo.radius }
-                    cy={ cy + nodeStyleInfo.radius }
-                />
-            }
-
-            {/* Edge highlight */}
+            
             { 
                 isActive && isEdge(type) && 
                 x1 !== undefined && x2 !== undefined &&
                 y1 !== undefined && y2 !== undefined &&
-                <line
-                    x1={x1}
-                    x2={x2}
-                    y1={y1}
-                    y2={y2}
-                    strokeWidth={nodeStyleInfo.strokeWidth}
-                    stroke="red"
-                    strokeDasharray="2,6"
-                    strokeLinecap="round"
-                    strokeOpacity={0.4}
-                />
-            }
-            
-            {
-                isActive && isEdge(type) &&
-                x1 !== undefined && y1 !== undefined &&
-                <HighlighterKnob
-                    cx={x1}
-                    cy={y1}
+                <EdgeHighlighter
+                    x1 = { x1 }
+                    x2 = { x2 }
+                    y1 = { y1 }
+                    y2 = { y2 }
+                    type = { type }
                 />
             }
 
-            {
-                isActive && isEdge(type) &&
-                x2 !== undefined && y2 !== undefined &&
-                <HighlighterKnob
-                    cx={x2}
-                    cy={y2}
+            { 
+                isActive && type === ComponentType.NODE && 
+                cx !== undefined && cy !== undefined &&
+                <NodeHighlighter
+                    cx = { cx }
+                    cy = { cy }
                 />
             }
             
-            {
-                isActive && type === ComponentType.UNIDIRECTIONALEDGE
-                && x2 !== undefined && y2 !== undefined &&
-                <polygon 
-                    points = {`${x2-triangleStyleInfo.sideLength},${y2} ${x2},${y2} ${x2},${y2+triangleStyleInfo.sideLength}`} 
-                    stroke="red"
-                    strokeDasharray="2,6"
-                    strokeLinecap="round"
-                    strokeOpacity={0.4}
-                />
-            }
         </g>
     )
 }

--- a/src/components/graph/node-highlighter.tsx
+++ b/src/components/graph/node-highlighter.tsx
@@ -1,0 +1,57 @@
+import { styleInfo as nodeStyleInfo } from  '../utils/node';
+import { HighlighterKnob } from '../graph/highlighter';
+
+export const NodeHighlighter = ({ cx, cy }: { cx: number, cy: number }) => {   
+    return (
+        <g>
+            <rect
+                height = { nodeStyleInfo.radius * 2 }
+                width = { nodeStyleInfo.radius * 2 }
+                x = { cx - nodeStyleInfo.radius }
+                y = { cy - nodeStyleInfo.radius }
+                strokeWidth={nodeStyleInfo.strokeWidth}
+                stroke="red"
+                strokeDasharray="2,6"
+                strokeLinecap="round"
+                fill="transparent"
+                strokeOpacity={0.4}
+            />
+            <g  
+                className="hover:cursor-grab"
+            >
+                <HighlighterKnob
+                    cx={ cx - nodeStyleInfo.radius }
+                    cy={ cy - nodeStyleInfo.radius }
+                />
+            </g>
+            
+            <g  
+                className="hover:cursor-grab"
+            >
+                <HighlighterKnob
+                    cx={ cx + nodeStyleInfo.radius }
+                    cy={ cy - nodeStyleInfo.radius }
+                />
+            </g>
+
+            <g  
+                className="hover:cursor-grab"
+            >
+                <HighlighterKnob
+                    cx={ cx - nodeStyleInfo.radius }
+                    cy={ cy + nodeStyleInfo.radius }
+                />
+            </g>
+            
+            <g  
+                className="hover:cursor-grab"
+            >
+                <HighlighterKnob
+                    cx={ cx + nodeStyleInfo.radius }
+                    cy={ cy + nodeStyleInfo.radius }
+                />
+            </g>
+            
+        </g>
+    )
+}

--- a/src/components/layout/canvas.fixture.tsx
+++ b/src/components/layout/canvas.fixture.tsx
@@ -555,12 +555,15 @@ const Canvas = () => {
         // console.log("Nodes: ", collisionManager.nodeGrid);
         // console.log(graphComponents.nodes);
         // console.log("Adjacency List: ", adjacencyList);
+        // console.log("y: ", y2 - y1, " x: ", x2 - x1);
+        // console.log("Angle of rotation: ", Math.atan2(y2 - y1, x2 - x1));
+        
     }
 
     const [isRepositionHighlighterX1Y1, setIsRepositionHighlighterX1Y1] = useState<boolean>(false);
     const [isRepositionHighlighterX2Y2, setIsRepositionHighlighterX2Y2] = useState<boolean>(false);
 
-    const [[repositionHighlighterXOffset, repositionHighlighterYOffset], setRepositionHighlighterXYOffset] = useState<[number, number]>([0, 0]);
+    const [[repositionHighlighterXOffset, repositionHighlighterYOffset], setRepositionHighlighterXYOffset] = useState<[number, number]>([0, 0]); // Can use this for node scaling too
     const [[repositionHighlighterAdjustedX, repositionHighlighterAdjustedY], setRepositionHighlighterAdjustedXY] = useState<[number, number]>([0, 0]);
 
     const cleanupRepositionState = () => {
@@ -791,6 +794,7 @@ const Canvas = () => {
                     if(isDraggingEdge) handleOnMouseUpEdge(e);
                     if(isRepositionHighlighterX1Y1) handleOnMouseUpX1Y1(e); 
                     if(isRepositionHighlighterX2Y2) handleOnMouseUpX2Y2(e);
+                    // console.log("Adjacency List: ", adjacencyList);
                 }}
                 id={`${CANVASID}`}
                 ref={svgRef}

--- a/src/components/layout/canvas.fixture.tsx
+++ b/src/components/layout/canvas.fixture.tsx
@@ -44,11 +44,11 @@ const Canvas = () => {
     const [ [ xDragOffsetNode, yDragOffsetNode ], setDragOffsetNode ] = useState<[number, number]>([0, 0]);
     const [ [ x1DragOffsetEdge, x2DragOffsetEdge, y1DragOffsetEdge, y2DragOffsetEdge ], setDragOffsetEdge ] = useState<[number, number, number, number]>([0, 0, 0, 0]);
 
+    // Node highligheter state during element drag and drop (separate from node scaling/single vertex repositioning)
     const [ [ isHighlightedEdge, highlightedEdgeID, highlightTypeEdge ], setHighlightEdge ] = useState<[boolean, EdgeID | undefined, ComponentType]>([false, undefined, ComponentType.NONE]);
     const [ [ x1EdgeHighlight, x2EdgeHighlight, y1EdgeHighlight, y2EdgeHighlight ], setHighlightEdgeCoords ] = useState<[number, number, number, number]>([0, 0, 0, 0]);
     const [ [ isHighlightedNode, highlightedNodeID, highlightTypeNode ], setHighlightNode ] = useState<[boolean, NodeID | undefined, ComponentType]>([false, undefined, ComponentType.NONE]);
     const [ [ cxNodeHighlight, cyNodeHighlight ], setHighlightNodeCoords ] = useState<[number, number]>([0, 0]);
-
 
     const [ svgCTM, setSVGCTM ] = useState<DOMMatrix | null>(null);
     const [ inverseSVGCTM, setInverseSVGCTM ] = useState<DOMMatrix | null>(null);
@@ -556,6 +556,131 @@ const Canvas = () => {
         // console.log(graphComponents.nodes);
         // console.log("Adjacency List: ", adjacencyList);
     }
+
+    const [isRepositionHighlighterX1Y1, setIsRepositionHighlighterX1Y1] = useState<boolean>(false);
+    const [isRepositionHighlighterX2Y2, setIsRepositionHighlighterX2Y2] = useState<boolean>(false);
+
+    const [[repositionHighlighterXOffset, repositionHighlighterYOffset], setRepositionHighlighterXYOffset] = useState<[number, number]>([0, 0]);
+    const [[repositionHighlighterAdjustedX, repositionHighlighterAdjustedY], setRepositionHighlighterAdjustedXY] = useState<[number, number]>([0, 0]);
+
+    const cleanupRepositionState = () => {
+        setIsRepositionHighlighterX1Y1(false);
+        setIsRepositionHighlighterX2Y2(false);
+        setRepositionHighlighterXYOffset([0, 0]);
+        setRepositionHighlighterAdjustedXY([0, 0]);
+    }
+
+    const handleOnMouseDownX1Y1 = (e: React.MouseEvent<SVGGElement, MouseEvent>) => {
+        // 1. Make a new highlighter object without end-of-vertex circles
+        setIsRepositionHighlighterX1Y1(true);
+
+        // 2. Calculate and set offset from center of end-of-vertex circle
+        if(!svgRef.current) {
+            cleanupRepositionState();
+            return;
+        }
+        const clickPointSVG = SVGFromGAndSVG(e.currentTarget, svgRef.current, e.clientX, e.clientY);
+        if(!clickPointSVG) {
+            cleanupRepositionState();
+            return;
+        }
+        setRepositionHighlighterXYOffset([clickPointSVG.x - x1EdgeHighlight, clickPointSVG.y - y1EdgeHighlight]);
+        setRepositionHighlighterAdjustedXY([x1EdgeHighlight, y1EdgeHighlight]);
+        
+        // 3. Make sure no undesired, residual onMouseDown effects trigger
+        e.stopPropagation();
+    }
+
+    const handleOnMouseDownX2Y2 = (e: React.MouseEvent<SVGGElement, MouseEvent>) => {
+        // 1. Make a new highlighter object without end-of-vertex circles
+        setIsRepositionHighlighterX2Y2(true);
+
+        // 2. Calculate and set offset from center of end-of-vertex circle
+        if(!svgRef.current) {
+            cleanupRepositionState();
+            return;
+        }
+        const clickPointSVG = SVGFromGAndSVG(e.currentTarget, svgRef.current, e.clientX, e.clientY);
+        if(!clickPointSVG) {
+            cleanupRepositionState();
+            return;
+        }
+        setRepositionHighlighterXYOffset([clickPointSVG.x - x2EdgeHighlight, clickPointSVG.y - y2EdgeHighlight]);
+        setRepositionHighlighterAdjustedXY([x2EdgeHighlight, y2EdgeHighlight]);
+        
+        // 3. Make sure no undesired, residual onMouseDown effects trigger
+        e.stopPropagation();
+    }
+
+    const handleOnMouseMoveX1Y1OrX2Y2 = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+        if(!isRepositionHighlighterX1Y1 && !isRepositionHighlighterX2Y2) {
+            cleanupRepositionState();
+            return;
+        }
+
+        // Throttle to 60FPS
+        const now = performance.now();
+        if (now - lastEventTime < throttleDelay) {
+            return;
+        }
+        setLastEventTime(now);
+        const result = DOMToSVGOnClick(e, svgCTM, inverseSVGCTM);
+        if(!result) {
+            console.log("Could not derive point");
+            cleanupRepositionState();
+            return;
+        }
+        const [x, y] = result;
+        setRepositionHighlighterAdjustedXY([x - repositionHighlighterXOffset, y - repositionHighlighterYOffset]);
+    }
+
+    const handleOnMouseUpX1Y1 = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+        if(!isRepositionHighlighterX1Y1) {
+            cleanupRepositionState();
+            return;
+        }
+        const result = DOMToSVGOnClick(e, svgCTM, inverseSVGCTM);
+        if(!result) {
+            cleanupRepositionState();
+            return;
+        }
+        const [x, y] = result;
+        const x1Moved = x - repositionHighlighterXOffset
+        const y1Moved = y - repositionHighlighterYOffset;
+        setHighlightEdgeCoords([x1Moved, x2EdgeHighlight, y1Moved, y2EdgeHighlight]);
+        updateEdgePosition(
+            highlightedEdgeID, 
+            x1Moved, 
+            x2EdgeHighlight,
+            y1Moved,
+            y2EdgeHighlight
+        );
+        cleanupRepositionState();
+    }
+
+    const handleOnMouseUpX2Y2 = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+        if(!isRepositionHighlighterX2Y2) {
+            cleanupRepositionState();
+            return;
+        }
+        const result = DOMToSVGOnClick(e, svgCTM, inverseSVGCTM);
+        if(!result) {
+            cleanupRepositionState();
+            return;
+        }
+        const [x, y] = result;
+        const x2Moved = x - repositionHighlighterXOffset
+        const y2Moved = y - repositionHighlighterYOffset;
+        setHighlightEdgeCoords([x1EdgeHighlight, x2Moved, y1EdgeHighlight, y2Moved]);
+        updateEdgePosition(
+            highlightedEdgeID, 
+            x1EdgeHighlight, 
+            x2Moved,
+            y1EdgeHighlight,
+            y2Moved
+        );
+        cleanupRepositionState();
+    }
     
     const renderNodes = (nodes: Map<NodeID, NodeIF>) => {
         const nodeComponents = [];
@@ -596,6 +721,7 @@ const Canvas = () => {
     const renderHighlighter = () => {
         if(isHighlightedEdge) {
             return(
+                <g>
                 <Highlighter
                     isActive={true}
                     type={highlightTypeEdge}
@@ -604,7 +730,24 @@ const Canvas = () => {
                     y1={y1EdgeHighlight}
                     y2={y2EdgeHighlight}
                     onMouseDown={(e) => {handleOnMouseDownEdge(e, highlightedEdgeID, highlightTypeEdge)}}
+                    onMouseDownX1Y1={ handleOnMouseDownX1Y1 }
+                    onMouseDownX2Y2={ handleOnMouseDownX2Y2 }
                 />
+                {
+                    (isRepositionHighlighterX1Y1 || isRepositionHighlighterX2Y2) &&
+                    <Highlighter
+                    isActive={true}
+                    type={highlightTypeEdge}
+                    x1={ isRepositionHighlighterX1Y1 ? repositionHighlighterAdjustedX : x1EdgeHighlight }
+                    x2={ isRepositionHighlighterX2Y2 ? repositionHighlighterAdjustedX : x2EdgeHighlight }
+                    y1={ isRepositionHighlighterX1Y1 ? repositionHighlighterAdjustedY : y1EdgeHighlight } 
+                    y2={ isRepositionHighlighterX2Y2 ? repositionHighlighterAdjustedY : y2EdgeHighlight }
+                    onMouseDown={undefined}
+                    onMouseDownX1Y1={undefined}
+                    onMouseDownX2Y2={undefined}
+                    />
+                }
+                </g>
             )
         } else if(isHighlightedNode) { 
             return(    
@@ -641,10 +784,13 @@ const Canvas = () => {
                 onMouseMove={(e) => {
                     if(isDraggingNode) handleOnMouseMoveNode(e);
                     if(isDraggingEdge) handleOnMouseMoveEdge(e);
+                    if(isRepositionHighlighterX1Y1 || isRepositionHighlighterX2Y2) handleOnMouseMoveX1Y1OrX2Y2(e);
                 }}
                 onMouseUp={(e) => {
                     if(isDraggingNode) handleOnMouseUpNode(e);
                     if(isDraggingEdge) handleOnMouseUpEdge(e);
+                    if(isRepositionHighlighterX1Y1) handleOnMouseUpX1Y1(e); 
+                    if(isRepositionHighlighterX2Y2) handleOnMouseUpX2Y2(e);
                 }}
                 id={`${CANVASID}`}
                 ref={svgRef}


### PR DESCRIPTION
1. Use the highlighter to rotate and scale vertices on the canvas.
2. Unidirectional vertex arrows rotate appropriately with vertex itself. 
3. Graph state maintained throughout reposition operation. 
4. NODE SCALING NOT INCLUDED (Lower priority feature, will implement later). 