### PR TITLE
Fix #6: Display, update, delete edge traversal costs

### DIFF
--- a/src/components/layout/toolbar.fixture.tsx
+++ b/src/components/layout/toolbar.fixture.tsx
@@ -114,7 +114,7 @@ const Toolbar = () => {
                                 {
                                     to: undefined, 
                                     from: undefined, 
-                                    cost: 0,
+                                    cost: undefined,
                                     type:componentType,
                                     x1: x1,
                                     x2: x2,

--- a/src/components/utils/edge.tsx
+++ b/src/components/utils/edge.tsx
@@ -28,7 +28,8 @@ export interface EdgeIF {
 
 // Styling for the center circle allowing visible edge cost
 export const styleInfo = {
-    fill: "red",
+    fill: "#66FF99", // light green
+    focusFill: "orange",
     stroke: "transparent",
 };
 


### PR DESCRIPTION
Double clicking a vertex allows user to update edge traversal cost. 

1. No cost displayed means undefined.
2. Cost displayed in a light green circle means that cost is set and state is updated.
3. Cost displayed in an orange circle means cost is not yet set and state remains unchanged. 
4. Decision to allow multiple vertex to be orange simultaneously was intentional. 